### PR TITLE
Fix omniauth-oauth2 (1.4.0) compatibility and pickup profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# OmniAuth Shine 
+# OmniAuth Shine
 
-This gem contains an oauth2 Shine strategy for OmniAuth.
+This gem contains an oauth2 Shine strategy for OmniAuth to allow access to the Misfit Cloud API
 
-As of May 2014, the Misfit API is available by request. Contact Misfit for information.  
-
-http://misfitwearables.com 
-
+For documentation on accessing devices made by Misfit Wearables go to the
+[CloudAPI docs](https://build.misfit.com/docs/cloudapi/get_started).
 
 ## How To Use It
 
@@ -26,16 +24,21 @@ end
 
 You will obviously have to put in your key and secret, which you get when you register your app with Misfit.
 
+Many people put these values into environment variables to keep them out of source control. If you do that, your `config/initializers/omniauth.rb` will look like:
+
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :shine, ENV["MISFIT_CONSUMER_KEY"], ENV["MISFIT_CONSUMER_SECRET"] end
+```
+
+and you'll put the values for MISFIT_CONSUMER_KEY & MISFIT_CONSUMER_SECRET in a `.env` file
+
 Now just follow the README at: https://github.com/intridea/omniauth
 
 
 ## User ID
 
-Some omniauth strategies are able to grab the user ID during the
-authenticatino process. This one does not. If you want the user ID then
-you will need to make a call to for the profile once you get a valid
-token.
-
+In order to get the User ID, this strategy makes an extra call to `/move/resource/v1/user/me/profile`. That also picks up name, email, avatar, birthday, and gender, so those are put into `auth_hash.info` also.
 
 ## Note on Patches/Pull Requests
 
@@ -50,3 +53,6 @@ token.
 
 MIT
 
+## Credits
+bsoule (https://github.com/bsoule)
+hungtd9 (https://github.com/hungtd9)

--- a/lib/omniauth/strategies/shine.rb
+++ b/lib/omniauth/strategies/shine.rb
@@ -15,11 +15,18 @@ module OmniAuth
       # error when returning via the moves: scheme link.
       # option :provider_ignores_state, true
 
+      uid { raw_info['userId'] }
 
-      # uid { raw_info['userId'] }
-      uid { '12345' }
-      # info do { :firstDate => (raw_info['profile'] || {})['firstDate'] } end
-      info do { :foo => 'fee' } end
+      info do
+        {
+          :name => raw_info['name'],
+          :email => raw_info['email'],
+          :avatar => raw_info['avatar'],
+          :birthday => raw_info['birthday'],
+          :gender => raw_info['gender']
+        }
+      end
+
       extra do { :raw_info => raw_info } end
 
       def request_phase
@@ -32,8 +39,7 @@ module OmniAuth
       end
 
       def raw_info
-        # @raw_info ||= access_token.get('https://api.misfitwearables.com/move/v1/user/me/profile').parsed
-        @raw_info
+        @raw_info ||= access_token.get('/move/resource/v1/user/me/profile').parsed
       end
 
       def callback_url

--- a/lib/omniauth/strategies/shine.rb
+++ b/lib/omniauth/strategies/shine.rb
@@ -36,6 +36,10 @@ module OmniAuth
         @raw_info
       end
 
+      def callback_url
+        options[:callback_url] || (full_host + script_name + callback_path)
+      end
+
       private
 
       def client_params

--- a/omniauth-shine.gemspec
+++ b/omniauth-shine.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = OmniAuth::Shine::VERSION
   s.authors     = ["Mathias Kolehmainen"]
   s.email       = ["mathias@countit.com"]
-  s.homepage    = "https://github.com/socialworkout/omniauth-shine"
+  s.homepage    = "https://github.com/countitlabs/omniauth-shine"
   s.summary     = %q{Misfit Shine strategy for OmniAuth.}
   s.description = %q{Misfit Shine strategy for OmniAuth.}
   s.license     = 'MIT'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   # s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.4'
 
   # s.add_development_dependency 'rspec', '~> 2.7'
 end


### PR DESCRIPTION
With omniauth-oauth2 (1.4.0), there was a breaking change around `callback_url`. The current version of the gem was picking up 1.4.0, but then crashing.

Since the Misfit Cloud API only returns an access_token, but no other information, after authorization, the UID was being populated with dummy values. This PR includes code to do a call to `/move/resource/v1/user/me/profile` to get UserId and (since that returns other info), it makes that available to in `auth_hash.info`.

This PR is just collecting work done on other folks and assembling it into a single pull request. Credit is given to the authors in the README. 
